### PR TITLE
Updated readme to redirect to correct binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Getting started (with Binder)
 
 Click on the Binder badge:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/shimming-toolbox/simulation-fourier-reconstruction)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/shimming-toolbox/simulation-fourier-reconstruction/HEAD)
 
 Wait for Binder to finish building the environment (can take 5-10 minutes), then click on the Jupyter notebook (`Fourier-reconstruction_in_MRI.ipynb`).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Getting started (with Binder)
 
 Click on the Binder badge:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/shimming-toolbox/simulation-fourier-reconstruction/gc/jupyter-notebook)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/shimming-toolbox/simulation-fourier-reconstruction)
 
 Wait for Binder to finish building the environment (can take 5-10 minutes), then click on the Jupyter notebook (`Fourier-reconstruction_in_MRI.ipynb`).
 


### PR DESCRIPTION
Switched binder link from old development branch `gc/fourier_notebook` to master branch.

The link in the binder badge used to redirect to the branch I used for development. Now that it has been merged, it should redirect to the master branch.